### PR TITLE
Increased precision to support big_m

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,4 +850,27 @@ mod tests {
         );
         assert_eq!(sol.objective(), 405.0);
     }
+
+    #[test]
+    fn solve_big_m() {
+        let mut problem = Problem::new(OptimizationDirection::Minimize);
+
+        let m = 1.0e9;
+
+        // Define variables with their objective coefficients
+        let x = problem.add_var(1.0, (0.0, f64::INFINITY));
+        let b = problem.add_binary_var(-1.0);
+
+        problem.add_constraint([(x, 1.0)], ComparisonOp::Ge, 5.0);
+        problem.add_constraint([(b, -m), (x, 1.0)], ComparisonOp::Le, 10.0);
+        problem.add_constraint([(b, -m), (x, 1.0)], ComparisonOp::Ge, -m + 10.0);
+
+        let sol = problem.solve().unwrap();
+
+        assert_eq!(
+            [*sol.var_value(x), *sol.var_value(b)],
+            [5.0, 0.0]
+        );
+        assert_eq!(sol.objective().round(), 5.0);
+    }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -10,7 +10,7 @@ use sprs::CompressedStorage;
 
 type CsMat = sprs::CsMatI<f64, usize>;
 
-const EPS: f64 = 1e-8;
+const EPS: f64 = f64::EPSILON*10.0;
 
 fn float_eq(a: f64, b: f64) -> bool {
     (a - b).abs() < EPS
@@ -1519,7 +1519,7 @@ fn choose_branch_var(cur_solution: &Solution, domain: &[VarDomain]) -> Option<Va
             continue;
         }
         let divergence = f64::abs(val - val.round());
-        if divergence > 1e-5 && divergence > max_divergence {
+        if divergence > EPS && divergence > max_divergence {
             max_divergence = divergence;
             max_var = Some(var);
         }


### PR DESCRIPTION
Fixes #7 
Increased the precision in the solver to help with using big_m

https://www.lindo.com/doc/online_help/lingo18_0/bigm_threshold.htm