### PR TITLE
Fix #22 - do not panic on time-limited MILP `solve()`

### DIFF
--- a/src/solver.rs
+++ b/src/solver.rs
@@ -669,6 +669,29 @@ impl Solver {
                 continue;
             }
 
+            // The time limit may have been reached while (re)optimizing this
+            // branch (deadlines are also checked inside `restore_feasibility`,
+            // not just in the loop above). In that case the solver is
+            // left primal-infeasible with unreliable variable values, so we
+            // must not branch on it: doing so would push steps whose
+            // `start_solution` is primal-infeasible and later call
+            // `add_constraint` on them, tripping its
+            // `assert!(self.is_primal_feasible)`. Re-queue this step and stop,
+            // persisting B&B state so the search can be resumed.
+            if cur_solution.stop_reason == StopReason::Limit {
+                dfs_stack.push(cur_step);
+                let has_best = best_solution.is_some();
+                if let Some(solution) = best_solution {
+                    *self = solution.solver;
+                }
+                self.bb_state = Some(BranchAndBoundState {
+                    dfs_stack,
+                    best_cost,
+                    has_best,
+                });
+                return Ok(StopReason::Limit);
+            }
+
             let obj_val = cur_solution.objective();
             if !is_solution_better(direction, best_cost, obj_val) {
                 debug!(

--- a/src/tests/resume.rs
+++ b/src/tests/resume.rs
@@ -99,56 +99,6 @@ mod tests_resume {
         (problem, vars)
     }
 
-    /// Regression test for https://github.com/Specy/microlp/issues/22
-    ///
-    /// Solving a MILP with a very tight time limit used to panic in
-    /// `add_constraint`. It must instead stop gracefully with
-    /// `StopReason::Limit`.
-    #[test]
-    fn time_limited_integer_variables_does_not_panic() {
-        init();
-
-        fn build_hard_knapsack() -> Problem {
-            let mut rng = SimpleRng::new(0x1234_5678_9ABC_DEF0);
-            let n = 60;
-            let mut problem = Problem::new(OptimizationDirection::Maximize);
-            let mut weight_terms = Vec::with_capacity(n);
-            let mut total_weight = 0.0;
-            for _ in 0..n {
-                let weight = rng.next_range(1, 97) as f64;
-                let value = rng.next_range(1, 89) as f64;
-                let x = problem.add_integer_var(value, (0, 1));
-                weight_terms.push((x, weight));
-                total_weight += weight;
-            }
-            problem.add_constraint(
-                weight_terms.as_slice(),
-                ComparisonOp::Le,
-                total_weight * 0.5,
-            );
-            problem
-        }
-
-        // Sanity check: the untimed solve finishes.
-        let problem = build_hard_knapsack();
-        let full = problem.solve().expect("untimed solve");
-        assert_eq!(*full.stop_reason(), StopReason::Finished);
-
-        // Run many times with a tight limit to reliably hit the deadline
-        // mid-branch-and-bound. Previously this panicked.
-        for _ in 0..50 {
-            let mut problem = build_hard_knapsack();
-            problem.set_time_limit(std::time::Duration::from_millis(1));
-            let solution = problem.solve().expect("timed solve must not error");
-            // Either it finished within the limit or it stopped at the limit;
-            // both are acceptable, neither should panic.
-            assert!(matches!(
-                solution.stop_reason(),
-                StopReason::Finished | StopReason::Limit
-            ));
-        }
-    }
-
     #[test]
     #[cfg_attr(debug_assertions, ignore = "test is too slow in debug mode")]
     fn resume_produces_same_result_as_unlimited() {
@@ -361,6 +311,145 @@ mod tests_resume {
             assert!(
                 float_eq(*a, *b),
                 "LP variable {} differs: unlimited = {}, resumed = {}",
+                i,
+                a,
+                b
+            );
+        }
+
+        assert!(
+            resume_count >= 1,
+            "Expected at least 1 resume call, got {}",
+            resume_count
+        );
+    }
+
+    /// Builds a hard bounded-knapsack MILP that genuinely benefits from general
+    /// integer variables (each item may be taken several times, not just 0/1).
+    fn build_complex_integer_knapsack() -> (Problem, Vec<Variable>) {
+        let mut rng = SimpleRng::new(0x0F1E_2D3C_4B5A_6978);
+
+        let num_items = 100;
+
+        let mut problem = Problem::new(OptimizationDirection::Maximize);
+
+        // Create integer variables with bounds well above 1 and pseudo-random
+        // objective coefficients, tracking their weights for two capacity
+        // constraints.
+        let mut vars = Vec::with_capacity(num_items);
+        let mut weight_terms = Vec::with_capacity(num_items);
+        let mut volume_terms = Vec::with_capacity(num_items);
+        let mut total_weight = 0.0;
+        let mut total_volume = 0.0;
+        for _ in 0..num_items {
+            let weight = rng.next_range(1, 97) as f64;
+            let volume = rng.next_range(1, 71) as f64;
+            let value = rng.next_range(1, 89) as f64;
+            let upper = rng.next_range(3, 9) as i32;
+            let x = problem.add_integer_var(value, (0, upper));
+            vars.push(x);
+            weight_terms.push((x, weight));
+            volume_terms.push((x, volume));
+            total_weight += weight * upper as f64;
+            total_volume += volume * upper as f64;
+        }
+
+        // Capacities are set to ~40% of the total — tight enough to force heavy
+        // branching across the integer domains.
+        problem.add_constraint(
+            weight_terms.as_slice(),
+            ComparisonOp::Le,
+            total_weight * 0.4,
+        );
+        problem.add_constraint(
+            volume_terms.as_slice(),
+            ComparisonOp::Le,
+            total_volume * 0.4,
+        );
+
+        (problem, vars)
+    }
+
+    /// Regression test for https://github.com/Specy/microlp/issues/22, where a
+    /// time-limited MILP solve used to panic instead of stopping gracefully.
+    #[test]
+    fn resume_integer_variables_produces_same_result_as_unlimited() {
+        init();
+
+        // ── 1. Solve without any time limit ──────────────────────────────────
+        let (problem_unlimited, vars_unlimited) = build_complex_integer_knapsack();
+
+        let t0 = std::time::Instant::now();
+        let sol_unlimited = problem_unlimited.solve().unwrap();
+        let elapsed_unlimited = t0.elapsed();
+
+        assert_eq!(
+            sol_unlimited.stop_reason(),
+            &StopReason::Finished,
+            "Unlimited solve should finish"
+        );
+
+        let values_unlimited: Vec<f64> = vars_unlimited
+            .iter()
+            .map(|v| sol_unlimited.var_value(*v))
+            .collect();
+        let obj_unlimited = sol_unlimited.objective();
+
+        println!(
+            "MILP unlimited solve: objective = {:.6}, time = {:.3}s",
+            obj_unlimited,
+            elapsed_unlimited.as_secs_f64()
+        );
+
+        // ── 2. Solve the same problem with repeated short time limits ────────
+        let (mut problem_limited, vars_limited) = build_complex_integer_knapsack();
+        problem_limited.set_time_limit(Duration::from_millis(1));
+
+        let t1 = std::time::Instant::now();
+        let mut sol_limited = problem_limited.solve().unwrap();
+
+        let mut resume_count = 0u32;
+        while *sol_limited.stop_reason() == StopReason::Limit {
+            resume_count += 1;
+            sol_limited = sol_limited.resume(Some(Duration::from_millis(1))).unwrap();
+        }
+        let elapsed_limited = t1.elapsed();
+
+        assert_eq!(
+            sol_limited.stop_reason(),
+            &StopReason::Finished,
+            "Resumed MILP solve should eventually finish"
+        );
+
+        let values_limited: Vec<f64> = vars_limited
+            .iter()
+            .map(|v| sol_limited.var_value(*v))
+            .collect();
+        let obj_limited = sol_limited.objective();
+
+        println!(
+            "MILP resumed solve:  objective = {:.6}, time = {:.3}s, resumes = {}",
+            obj_limited,
+            elapsed_limited.as_secs_f64(),
+            resume_count
+        );
+
+        // ── 3. Compare results ───────────────────────────────────────────────
+        assert!(
+            float_eq(obj_unlimited, obj_limited),
+            "MILP objectives differ! unlimited = {}, resumed = {}",
+            obj_unlimited,
+            obj_limited
+        );
+
+        for (i, (a, b)) in values_unlimited
+            .iter()
+            .zip(values_limited.iter())
+            .enumerate()
+        {
+            assert!(
+                float_eq(*a, *b),
+                "MILP variable {} differs: unlimited = {}, resumed = {}",
                 i,
                 a,
                 b

--- a/src/tests/resume.rs
+++ b/src/tests/resume.rs
@@ -99,6 +99,56 @@ mod tests_resume {
         (problem, vars)
     }
 
+    /// Regression test for https://github.com/Specy/microlp/issues/22
+    ///
+    /// Solving a MILP with a very tight time limit used to panic in
+    /// `add_constraint`. It must instead stop gracefully with
+    /// `StopReason::Limit`.
+    #[test]
+    fn time_limited_integer_variables_does_not_panic() {
+        init();
+
+        fn build_hard_knapsack() -> Problem {
+            let mut rng = SimpleRng::new(0x1234_5678_9ABC_DEF0);
+            let n = 60;
+            let mut problem = Problem::new(OptimizationDirection::Maximize);
+            let mut weight_terms = Vec::with_capacity(n);
+            let mut total_weight = 0.0;
+            for _ in 0..n {
+                let weight = rng.next_range(1, 97) as f64;
+                let value = rng.next_range(1, 89) as f64;
+                let x = problem.add_integer_var(value, (0, 1));
+                weight_terms.push((x, weight));
+                total_weight += weight;
+            }
+            problem.add_constraint(
+                weight_terms.as_slice(),
+                ComparisonOp::Le,
+                total_weight * 0.5,
+            );
+            problem
+        }
+
+        // Sanity check: the untimed solve finishes.
+        let problem = build_hard_knapsack();
+        let full = problem.solve().expect("untimed solve");
+        assert_eq!(*full.stop_reason(), StopReason::Finished);
+
+        // Run many times with a tight limit to reliably hit the deadline
+        // mid-branch-and-bound. Previously this panicked.
+        for _ in 0..50 {
+            let mut problem = build_hard_knapsack();
+            problem.set_time_limit(std::time::Duration::from_millis(1));
+            let solution = problem.solve().expect("timed solve must not error");
+            // Either it finished within the limit or it stopped at the limit;
+            // both are acceptable, neither should panic.
+            assert!(matches!(
+                solution.stop_reason(),
+                StopReason::Finished | StopReason::Limit
+            ));
+        }
+    }
+
     #[test]
     #[cfg_attr(debug_assertions, ignore = "test is too slow in debug mode")]
     fn resume_produces_same_result_as_unlimited() {


### PR DESCRIPTION
Fixes #22

I'm new to this repository and don't understand the implementation well. This particular solution was written by Claude Opus 4.8. Feel free to close this and/or fix the bug a different way! The included regression test fails without this change.