### PR TITLE
fix: correct author email in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "microlp"
 version = "0.4.0"
 authors = [
     "Alexey Zatelepin <alex.zatelepin@gmail.com>",
-    "Specy <specy.dev@gmai.com"
+    "Specy <specy.dev@gmail.com>"
 ]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Fix a typo in the `authors` field: `gmai.com` → `gmail.com` and add the missing closing bracket.